### PR TITLE
fix: 1003 error when path contains + plus sign

### DIFF
--- a/synology_drive_api/utils.py
+++ b/synology_drive_api/utils.py
@@ -32,7 +32,7 @@ def form_urlencoded(data: dict) -> str:
     """
     data_list = []
     for key, value in data.items():
-        value_encode = urllib.parse.quote(json.dumps(value), safe='') if not isinstance(value, str) else value
+        value_encode = urllib.parse.quote(json.dumps(value) if not isinstance(value, str) else value, safe='')
         # [key, '=', value_encode]
         data_list.append(f"{key}={value_encode}")
     urlencoded_data = '&'.join(data_list)


### PR DESCRIPTION
Encountered `1003 error` when use `get_file_or_folder_info` for a file path containing `+`. Don't have enough test cases, so I'm not sure whether this change will impact other api requests...