### PR TITLE
Changing upload path to be base name of file....

### DIFF
--- a/synology_drive_api/files.py
+++ b/synology_drive_api/files.py
@@ -141,7 +141,7 @@ class FilesMixin:
                                 Default is 'version', same as UI default behaviour.
         :return:
         """
-        file_name = file.name
+        file_name = os.basename(file.name)
         display_path = concat_drive_path(dest_folder_path, file_name)
         api_name = 'SYNO.SynologyDrive.Files'
         endpoint = 'entry.cgi'

--- a/synology_drive_api/files.py
+++ b/synology_drive_api/files.py
@@ -141,7 +141,7 @@ class FilesMixin:
                                 Default is 'version', same as UI default behaviour.
         :return:
         """
-        file_name = os.basename(file.name)
+        file_name = os.path.basename(file.name)
         display_path = concat_drive_path(dest_folder_path, file_name)
         api_name = 'SYNO.SynologyDrive.Files'
         endpoint = 'entry.cgi'


### PR DESCRIPTION
When doing an upload, by first opening a file, it takes the name of the path to upload the file. The problem is that it creates every folder that appears in its local path instead of only the file name. I don't know if this is the expected behavior, but I find it better this way because you get to decide exactly where to put it.   